### PR TITLE
Add Jobo

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
   1.  [DevOpsJobs](https://devopsprojectshq.com) DevOps, SRE, Cloud and Platform engineering jobs
   1. [UI/UX Jobs Board](https://uiuxjobsboard.com/design-jobs/remote) - Remote jobs for UI/UX designers
   1. [EmbeddedJobs](https://embedded.jobs) — Remote job board dedicated to embedded systems engineers and developers.
+  1. [Jobo](https://jobo.pl) - 100% remote-only verified jobs from Poland in IT, marketing, sales & more.
 
 
 ## Job boards aggregators
@@ -597,3 +598,4 @@ A curated list of awesome [remote working](https://en.wikipedia.org/wiki/Telecom
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Lukasz Madon](https://github.com/lukasz-madon) has waived all copyright and related or neighboring rights to this work.
+


### PR DESCRIPTION
Focus on the Polish market, but open to international remote work. All offers are 100% remote-only, no hidden hybrid jobs.